### PR TITLE
fix(manifest.yaml): Update the commit for lapack-feedstock

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -16,7 +16,7 @@ feedstocks:
     commit: d967b517eb3ba5ceba1f273db5ffc858ca1e430f
   lapack-feedstock:
     branch: main
-    commit: 530bac9d7a53b9b243cb178faade8947b8b130b6
+    commit: ea070f43a481a76d076ecb59709ce1a3bdcc182a
   numpy-feedstock:
     branch: main
     commit: 0c871b5d6b4a05080e27c74238e98bb9d7dddd18


### PR DESCRIPTION
We updated the feedstocks build.sh file, moving the commit for the aggregate to include the feedstock update.

Jira: CR-54