### PR TITLE
build: Add osx-arm64 workspace configuration

### DIFF
--- a/workspaces/workspace.osx-arm64.yaml
+++ b/workspaces/workspace.osx-arm64.yaml
@@ -1,0 +1,6 @@
+aggregate_ref: main
+aggregate_repo: git@github.com:anaconda-community/aggregate.git
+channels: []
+recipes:
+- lapack-feedstock
+- numpy-feedstock


### PR DESCRIPTION
Currently configured for numpy. `abs workspace build` completes successfully.

Jira: CR-54