### PR TITLE
feat(workspace.osx-arm64.yaml): Add boto3 and urlib3 feedstocks along…

### DIFF
--- a/workspaces/workspace.osx-arm64.yaml
+++ b/workspaces/workspace.osx-arm64.yaml
@@ -4,3 +4,17 @@ channels: []
 recipes:
 - lapack-feedstock
 - numpy-feedstock
+- pycparser-feedstock
+# - certifi-feedstock (encountered issue with `importlib.util` has no attribute `abc`
+- cffi-feedstock
+# - cryptography-feedstock (encountered issue loading libiconv)
+- idna-feedstock
+- pyopenssl-feedstock
+- pysocks-feedstock
+- urllib3-feedstock
+- python-dateutil-feedstock
+- six-feedstock
+- jmespath-feedstock
+- botocore-feedstock
+- s3transfer-feedstock
+- boto3-feedstock


### PR DESCRIPTION
… with dependencies to workspace

Ran build on osx-arm64. Feedstocks build successfully with the exception of certify and cryptography.

Jira: CR-45