### PR TITLE
feat: build order

### DIFF
--- a/.github/workflows/add-repo.yml
+++ b/.github/workflows/add-repo.yml
@@ -2,14 +2,16 @@ name: "Add repo"
 on:
   workflow_dispatch:
     inputs:
-      repoUrl:
-        description: 'URL for feedstock that will be added. To add multiple at once separate by a space'
+      feedstocks:
+        description: 'Feedstocks that will be added. To add multiple at once separate comma'
         required: true
         type: string
 permissions: write-all
 
 jobs:
-  add-repo:
+  validate-input:
+    outputs:
+      feedstocks: ${{ steps.prune.outputs.feedstocks }}
     defaults:
       run:
         shell: bash -l {0}
@@ -17,39 +19,48 @@ jobs:
     steps:
       - name: Validate input
         run: |
-          for repo in $REPO_LIST; do 
+          for repo in ${REPO_LIST//,/ }; do 
             echo "Checking input $repo"
-            if [[ ! $repo =~ ^http.*conda-forge/[A-Za-z0-9_.-]+-feedstock$ ]]; then
-                echo "Invalid input $repo. Please enter repos of the form https://github.com/conda-forge/<library>-feedstock"
+            if [[ ! $repo =~ ^[A-Za-z0-9_.-]+-feedstock$ ]]; then
+                echo "Invalid input $repo. Please enter in of the form <library>-feedstock"
                 exit 1
             fi
           done
           echo "Valid input"
         env:
-          REPO_LIST: ${{ github.event.inputs.repoUrl }}
+          REPO_LIST: ${{ github.event.inputs.feedstocks }}
 
-      - name: Check if repo already exists
+      - name: Prune repos that already exists
+        id: prune
         run: |
           # Check gh is authenticated
           gh auth status >/dev/null || exit 1
-          for repo in $REPO_LIST; do
-            NEW_FEEDSTOCK=$(echo $repo | sed -r 's#^http.*conda-forge/([A-Za-z0-9_.-]+-feedstock)$#\1#')
+          addlist=""
+          for NEW_FEEDSTOCK in ${REPO_LIST//,/ }; do
             echo "Checking if anaconda-community/${NEW_FEEDSTOCK} already exists"
             # Check if the repo has already been forked
-            gh repo view anaconda-community/${NEW_FEEDSTOCK} > /dev/null && echo "anaconda-community/${NEW_FEEDSTOCK} already exists" && exit 1 || echo "anaconda-community/${NEW_FEEDSTOCK} does not exist"
+            gh repo view anaconda-community/${NEW_FEEDSTOCK} > /dev/null && echo "anaconda-community/${NEW_FEEDSTOCK} already exists" || addlist+="${NEW_FEEDSTOCK},"
           done
+          echo "feedstocks=$addlist" >> $GITHUB_OUTPUT
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-          REPO_LIST: ${{ github.event.inputs.repoUrl }}
+          REPO_LIST: ${{ github.event.inputs.feedstocks }}
 
+  add-repo:
+    needs: validate-input
+    defaults:
+      run:
+        shell: bash -l {0}
+    runs-on: ubuntu-latest
+    steps:
       - name: Fork repo
         run: |
-          for repo in $REPO_LIST; do
-            gh repo fork $repo --org anaconda-community --clone=false --default-branch-only
+          for repo in ${REPO_LIST//,/ }; do
+            gh repo fork https://github.com/conda-forge/$repo --org anaconda-community --clone=false --default-branch-only
           done
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-          REPO_LIST: ${{ github.event.inputs.repoUrl }}
+          REPO_LIST: ${{ needs.validate-input.outputs.feedstocks }}
 
       - name: Checkout
         uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3
@@ -74,17 +85,16 @@ jobs:
           git config user.email "<>"
           branch=$(date +addfeedstocks%Y%m%d%H%M%S)
           git checkout -b $branch
-          for repo in $REPO_LIST; do
-            feedstock=${repo:31}
-            hash=$(git ls-remote https://github.com/anaconda-community/${feedstock}.git | head -n1 | awk '{print $1;}')
-            abs aggregate add --branch main --commit ${hash} ${feedstock}
+          for repo in ${REPO_LIST//,/ }; do
+            hash=$(git ls-remote https://github.com/anaconda-community/${repo}.git | head -n1 | awk '{print $1;}')
+            abs aggregate add --branch main --commit ${hash} ${repo}
           done
           yq --yaml-output --in-place . manifest.yaml
           git add manifest.yaml
           git commit -m "add ${REPO_LIST}"
           git push --set-upstream origin $branch
         env:
-          REPO_LIST: ${{ github.event.inputs.repoUrl }}
+          REPO_LIST: ${{ needs.validate-input.outputs.feedstocks }}
 
       - name: Open PR
         run: gh pr create --fill --label "manifest-add"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,8 @@ name: "Build feedstock"
 on:
   workflow_dispatch:
     inputs:
-      feedstocks:
-        description: 'Feedstocks to build in order, comma separated'
+      package:
+        description: 'Package to build'
         required: true
         type: string
       arch:
@@ -42,13 +42,46 @@ env:
 
 
 jobs:
+  build-order:
+    defaults:
+      run:
+        shell: bash -l {0}
+    runs-on: ubuntu-latest
+    outputs:
+      feedstocks: ${{ steps.build-order.outputs.feedstocks }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3
+
+      - uses: actions/cache@v2
+        with:
+          path: /usr/share/miniconda3/envs/agg
+          key: conda-${{ hashFiles('environment.yml') }}
+
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          auth-activate-base: false
+          activate-environment: agg
+          channels: distro-tooling,conda-forge
+          python-version: 3.9
+          mamba-version: "*"
+          environment-file: environment.yml
+
+      - name: Get build order
+        id: build-order
+        run: |
+          python tools/find_deps.py -p ${{ inputs.package }} > output.log
+          feedstocks=$(tail -n 1 output.log)
+          echo "feedstocks=$feedstocks" >> $GITHUB_OUTPUT
+
   build:
+    needs: build-order
     defaults:
       run:
         shell: bash -l {0}
     runs-on: ubuntu-latest
     steps:
       - name: Start build
-        run: gh -R anaconda-distribution/rocket-platform workflow run "$ACTION" -f feedstock=${{ inputs.feedstocks }} -f arch=${{ inputs.arch }} -f action_runner=${{ inputs.action_runner }} -f container_runtime=${{ inputs.container_runtime }} -f branch=${{ inputs.branch }}
+        run: gh -R anaconda-distribution/rocket-platform workflow run "$ACTION" -f feedstock=${{ needs.build-order.outputs.feedstocks }} -f arch=${{ inputs.arch }} -f action_runner=${{ inputs.action_runner }} -f container_runtime=${{ inputs.container_runtime }} -f branch=${{ inputs.branch }}
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 ## Add repo
 To add a new repo go to the 'Actions' tab in GitHub and select 'Add repo' action.
-For input we expect a conda-forge GitHub url. 
+For input use a conda-forge feedstock. Separate multiple feedstocks by comma
 
-Example: https://github.com/conda-forge/7za-feedstock
+Example: 7za-feedstock,7zip-feedstock
 
 This will fork the repo into anaconda-community org and create a PR that adds this feedstock to manifest
 

--- a/environment.yml
+++ b/environment.yml
@@ -6,4 +6,7 @@ dependencies:
   - python=3.9
   - abs-cli
   - abs-sdk
+  - pyyaml
+  - jinja2
+  - cachetools
   - yq

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,16 @@
+# TOOLS
+
+## find_deps.py
+
+This project was copied from https://github.com/anaconda-distribution/distro-incubator/tree/main/akabanovs/pkg_check_availability and modified.
+
+This Python script generates a dependency tree for a specified package found on the conda-forge channel by default. The tool inspects the
+run dependencies required to build the package and checks for the existence of these dependencies conda-forge. It will output a list feedstocks in build order
+
+To install, create a new conda environment and install:
+	- pyyaml
+	- jinja2
+
+To run provide package name
+
+`python find_deps.py -p urllib3`

--- a/tools/find_deps.py
+++ b/tools/find_deps.py
@@ -1,0 +1,524 @@
+#!/usr/bin/env python
+# This was modified from https://github.com/anaconda-distribution/distro-incubator/blob/main/akabanovs/pkg_check_availability/pkg_check_availability.py
+import argparse
+import json
+import operator
+import os
+import re
+import warnings
+
+import requests
+import yaml
+from cachetools import Cache, LRUCache, cached
+from pkg_resources import parse_version
+from render import load_template_string
+from selector_support import evaluate_arch_selector
+
+cache: Cache = LRUCache(maxsize=1000)
+
+warnings.simplefilter("ignore")
+
+
+def ver_in_range(verCand, verRange):
+    inRange = True
+    if verRange != " ":
+        for verPart in verRange.split(","):
+            if ">=" in verPart:
+                op = operator.ge
+                ver = verPart.split(">=")[1]
+            elif ">" in verPart:
+                op = operator.gt
+                ver = verPart.split(">")[1]
+            elif "<=" in verPart:
+                op = operator.le
+                ver = verPart.split("<=")[1]
+            elif "<" in verPart:
+                op = operator.lt
+                ver = verPart.split("<")[1]
+            elif "!=" in verPart:
+                op = operator.ne
+                ver = verPart.split("!=")[1]
+            elif "==" in verPart:
+                op = operator.eq
+                ver = verPart.split("==")[1]
+            elif "=" in verPart:
+                op = operator.eq
+                ver = verPart.split("=")[1]
+            else:
+                op = operator.eq
+                ver = verPart
+            if not op(parse_version(verCand), parse_version(ver)):
+                inRange = False
+                break
+    return inRange
+
+
+def get_requirements(data, name, section, attribute):
+    if str(data.get("package", {}).get("name", {})) != name and attribute != "version":
+        for out in data.get("outputs", {}):
+            if str(out.get("name", {})) == name:
+                reqs = out.get(section, {}).get(attribute, [])
+                break
+    else:
+        reqs = data.get(section, {}).get(attribute, [])
+    return reqs
+
+
+def read_requirements(data, name, section, attribute):
+    try:
+        req = get_requirements(data, name, section, attribute)
+        if not isinstance(req, list):
+            req = []
+    except:
+        req = []
+    return req
+
+
+@cached(cache)
+def is_recipe_available(pkg_name: str, lookup: bool):
+    if pkg_name.startswith("ctng-compilers-"):
+        return False, ""
+    url = f"{github_base_url}/conda-forge/{pkg_name}-feedstock/main/recipe/meta.yaml"
+    response = session.get(url, allow_redirects=False)
+    if response.status_code != 200:
+        if lookup:
+            return is_recipe_available(lookup_feedstock_name(pkg_name), False)
+        return False, ""
+    ordered_feedstocks[f"{pkg_name}-feedstock"] = url
+    return True, "main"
+
+
+@cached(cache)
+def raw_text_load(name, branch):
+    url = f"{github_base_url}/conda-forge/{name}-feedstock/{branch}/recipe/meta.yaml"
+    response = session.get(url, allow_redirects=False)
+    if response.status_code != 200:
+        print(f"Could not find feedstock at {url}")
+        print(f"Error [{response.status_code}]: {response.reason}")
+        return ""
+    data = response.text
+    template = load_template_string(data)
+    return template
+
+
+def get_deps(name, branch, archs, check_version_check_selector):
+    template = raw_text_load(name, branch)
+    if template == "":
+        return {}, "0"
+    data = yaml.load(template, Loader=yaml.SafeLoader)
+    # Get collection of required dependencies (may not be unique)
+    deps_collection = read_requirements(data, name, "requirements", "run")
+
+    deps_dict = {}
+    if len(deps_collection) > 0:
+        if check_version_check_selector:
+            # Process selectors, e.g. # [osx and linux]
+            # Process txt as yaml does not include commets.
+            # Find the line from which to start the search first
+            doSearch = False
+            template_splitlines = template.splitlines()
+            for index, line in enumerate(template_splitlines):
+                if "name" in line and line.split()[-1] == name:
+                    doSearch = True
+                if doSearch and "requirements:" in line:
+                    break
+
+            # Do the search of each dependency and evaluate the arch-specific selector.
+            for dep in deps_collection:
+                dep = dep.lower()
+                if dep not in deps_dict and isinstance(dep, str):
+                    for lineIndex in range(index, len(template_splitlines)):
+                        line = template_splitlines[lineIndex]
+                        if dep.split()[0] in line.split():
+                            expression = ""
+                            if len(line.split("# [")) > 1:
+                                expression = re.findall("\[(.*?)\]", line)[0]
+                            deps_dict[dep] = evaluate_arch_selector(archs, expression)
+                            break
+        else:
+            for dep in deps_collection:
+                if dep not in deps_dict and isinstance(dep, str):
+                    deps_dict[dep] = []
+
+    return deps_dict, get_requirements(data, name, "package", "version")
+
+
+def guess_feedstock_name(dep, separator, checksep):
+    if not separator in dep:
+        return False, dep, ""
+    dep = dep.replace(separator, checksep)
+    depname_split = dep.split(separator)
+    for ind, check_dep in reversed(list(enumerate(depname_split))):
+        partOfPKG = separator.join(depname_split[: ind + 1])
+        repo_avail, def_branch = is_recipe_available(partOfPKG, True)
+        if repo_avail:
+            # Found the repo! Now need to check if the package is mentioned here
+            data = yaml.load(raw_text_load(partOfPKG, def_branch), Loader=yaml.SafeLoader)
+            for out in data.get("outputs", {}):
+                # Try both combinations
+                if str(out.get("name", {})) == dep:
+                    return True, partOfPKG, def_branch
+                if str(out.get("name", {})) == dep.replace(checksep, separator):
+                    return True, partOfPKG, def_branch
+    return False, dep, ""
+
+
+@cached(cache)
+def lookup_feedstock_name(dep):
+    deplist = list(dep)
+    url = f"{github_base_url}/conda-forge/feedstock-outputs/main/outputs/{deplist[0]}/{deplist[1]}/{deplist[2]}/{dep}.json"
+    response = session.get(url, allow_redirects=False)
+    if response.status_code != 200:
+        print(f"Could not find feedstock at {url}")
+        print(f"Error [{response.status_code}]: {response.reason}")
+        return ""
+    return json.loads(response.text)["feedstocks"][0]
+
+
+def scan_arch(dep, ver_range, rdata):
+    available = False
+    in_range = False
+    for r in rdata["packages"].values():
+        if dep == r["name"]:
+            available = True
+            if ver_range:
+                if ver_in_range(r["version"], ver_range):
+                    in_range = True
+                    break
+    return available, in_range
+
+
+def print_level(deps, archSupport, prefix, check_version_check_selector, expand_tree):
+    for index, key in enumerate(deps.keys()):
+        # Construct the full prefix:
+        if index == len(deps) - 1:
+            br = "└──"
+            prefix2 = prefix + "    "
+            comment_prefix = "\n" + prefix + "    "
+        else:
+            br = "├──"
+            prefix2 = prefix + "│   "
+            comment_prefix = "\n" + prefix + "│   "
+        constrLine = prefix + br
+
+        # Derive dependency's actual name and version range
+        dep = key.split()
+        ver_range = ""
+        if len(dep) > 1:
+            ver_range = dep[1]
+        dep = dep[0]
+        if dep.__eq__("python"):
+            continue
+        if dep.startswith("ctng-compilers-"):
+            continue
+        if dep.startswith("_"):
+            continue
+
+        # Construct line:
+        constrLine += dep
+        if check_version_check_selector:
+            constrLine += " " + ver_range
+
+        # Initialise vars related to dependency's architecture selectors
+        archSupportDep = archSupport.copy()
+        extraInfo = ""
+
+        # Further initialise some flags to track dependency availability
+        pkg_avail = False
+        repo_avail = True
+        pkg_avail_on_noarch = False
+
+        # Check if dependency is available and populate availability arrays
+        # print("Checking " + dep)
+        if dep in avail_pkg:
+            pkg_avail = True
+        elif "conda" in dep:
+            repo_avail = False
+        else:
+            if dep not in unavail_pkg:
+                repo_avail, def_branch = is_recipe_available(dep, True)
+                # conda forge sometimes uses '-' as a separator while we use '_', and vice versa. Check:
+                if not repo_avail:
+                    repo_avail, dep, def_branch = guess_feedstock_name(dep, "-", "-")
+                    if not repo_avail:
+                        repo_avail, dep, def_branch = guess_feedstock_name(dep, "-", "_")
+                    if not repo_avail:
+                        repo_avail, dep, def_branch = guess_feedstock_name(dep, "_", "_")
+                    if not repo_avail:
+                        repo_avail, dep, def_branch = guess_feedstock_name(dep, "_", "-")
+                    if repo_avail:
+                        constrLine += " (subpackage of " + dep + "-feedstock)"
+
+                if repo_avail:
+                    pkg_avail = is_recipe_available(dep, True)
+                    if pkg_avail:
+                        avail_pkg.append(dep)
+                        depsOfdep, version = get_deps(
+                            dep,
+                            def_branch,
+                            archSupportDep,
+                            check_version_check_selector,
+                        )
+                        print_level(
+                            depsOfdep,
+                            archSupportDep,
+                            prefix2,
+                            check_version_check_selector,
+                            expand_tree,
+                        )
+                    else:
+                        unavail_pkg.append(dep)
+                        unavail_pkg.append(def_branch)
+
+        # Take into account (if specified) version range and (if specified) arch selectors:
+        if check_version_check_selector:
+            archSupportDep = []
+            verAvailInfo = ""
+            archAvailInfo = ""
+            for arch in archSupport:
+                if arch == "noarch":
+                    continue
+                arch_req = deps[key][arch]
+                if arch_req:
+                    archSupportDep.append(arch)
+
+            # If package is present on anaconda.org (pkg_avail), do further refinement to see if it is
+            # available for a specific version range, also taking into account arch selectors:
+            if pkg_avail:
+                for arch in archSupportDep:
+                    available, in_range = scan_arch(dep, ver_range, rdata[arch])
+                    if not available:
+                        if not archAvailInfo:
+                            archAvailInfo = (
+                                comment_prefix
+                                + "- Unavailable:"
+                            )
+                        archAvailInfo += arch + ";"
+                    if available and (not in_range and ver_range):
+                        if not verAvailInfo:
+                            verAvailInfo = (
+                                comment_prefix
+                                + "- Version requirements not met:"
+                            )
+                        verAvailInfo += arch + ";"
+
+                # If not found for any of the specified archs, try searching on noarch channel:
+                if verAvailInfo or archAvailInfo:
+                    available, in_range = scan_arch(dep, ver_range, rdata["noarch"])
+                    if available:
+                        archAvailInfo += (
+                            comment_prefix
+                            + "- Available on noarch"
+                        )
+                        if in_range or not ver_range:
+                            pkg_avail_on_noarch = True
+                            archAvailInfo += (
+                                " and version OK"
+                            )
+                        else:
+                            archAvailInfo += (
+                                " but version NOT OK"
+                            )
+                    else:
+                        archAvailInfo += " noarch;"
+                extraInfo = verAvailInfo + archAvailInfo
+
+        # Finally, write info to screen
+        if pkg_avail:
+            if not extraInfo or pkg_avail_on_noarch:
+                if expand_tree:
+                    print(
+                        constrLine
+                        + " (\u2713)"
+                        + extraInfo
+                       
+                    )
+            else:
+                print(constrLine + " (^)" + extraInfo)
+                if dep not in outdated_deps and not pkg_avail_on_noarch:
+                    outdated_deps.append(dep)
+        else:
+            if repo_avail:
+                def_branch = unavail_pkg[unavail_pkg.index(dep) + 1]
+                depsOfdep, version = get_deps(
+                    dep, def_branch, archSupportDep, check_version_check_selector
+                )
+                if ver_range and check_version_check_selector:
+                    if not ver_in_range(version, ver_range):
+                        extraInfo = (
+                            comment_prefix
+                            + "│   - Dependencies shown are for {} version {}.".format(
+                                dep, version
+                            )
+                        )
+                        extraInfo += (
+                            comment_prefix
+                            + "│     i.e. picked version does not match required version range - dependencies might be different."
+                        )
+                print(
+                    constrLine
+                    + " (!)"
+                    + extraInfo
+                   
+                )
+                if dep not in missing_deps:
+                    missing_deps.append(dep)
+                print_level(
+                    depsOfdep,
+                    archSupportDep,
+                    prefix2,
+                    check_version_check_selector,
+                    expand_tree,
+                )
+            else:
+                print(constrLine + " (?) ")
+                if dep not in check_manually:
+                    check_manually.append(dep)
+
+
+def check_dep_name(value):
+    pkg_name_pattern = re.compile("[a-zA-Z0-9-_]+(' '.*)*")
+    if not pkg_name_pattern.match(value):
+        raise argparse.ArgumentTypeError("The dependency name must be in the format <valid dependency name>")
+    return value
+
+
+def create_parser() -> argparse.ArgumentParser:
+    # Create parser for arguments and add arguments.
+    parser = argparse.ArgumentParser(
+        prog="check_avail",
+        description="This Python script generates a dependency tree for a specified package \
+                    found on the conda-forge channel by default. The tool inspects \
+                    the host and run dependencies required to build the package and checks for \
+                    the existence of these dependencies in the Anaconda main channel. This gives \
+                    the user an idea of how many missing or outdated dependencies there are, including their names.\n \n \
+                    Depending on the flags supplied, the output text will be colored. Here's what the \
+                    colors indicate:"
+        + " Dependency is present in the main channel (\u2713);"
+       
+        + " Dependency is not present in the main channel (!);"
+       
+        + " Dependency appears to be present on some architectures, but not all, \
+                    OR a newer version of the dependency is required (^);"
+       
+        + " Manual inspection of the dependency is required as it was not \
+                    possible to locate it's repo on conda-forge (?)."
+    )
+    popt = parser.add_mutually_exclusive_group(required=True)
+
+    popt.add_argument(
+        "-p",
+        "--package_name",
+        type=check_dep_name,
+        help="Package name available on conda-forge",
+    )
+    parser.add_argument(
+        "-a",
+        "--archs",
+        default="",
+        help="A list of architectures to consider when searching for dependencies in the main channel. \
+                     Should be specified as a string, space separated. E.g. 'osx-arm64 osx-64 linux-64'. If not used, \
+                     all supported architectures will be considered.",
+    )
+    parser.add_argument(
+        "--check-version-check-selector",
+        help="Dependencies in the recipe may have version range or architecrture selector specified. \
+                     By default these are not taken into account and script only scans for package availability. \
+                     The current flag adds these checks, thus giving the user a more detailed overview of package \
+                     availability and constraints.",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--expand-tree",
+        help="Flag to expand the dependency tree and include those packages that are available.",
+        action="store_true",
+    )
+    return parser
+
+
+supportedArchs = [
+    "linux-64",
+    "linux-ppc64le",
+    "linux-aarch64",
+    "linux-s390x",
+    "osx-64",
+    "osx-arm64",
+    "win-64",
+    "noarch",
+]
+github_base_url = "https://raw.githubusercontent.com"
+username = os.getenv("GIT_USERNAME")
+token = os.getenv("GIT_TOKEN")
+avail_pkg = []
+unavail_pkg = []
+
+missing_deps = []
+outdated_deps = []
+check_manually = []
+session = requests.Session()
+rdata = {}
+ordered_feedstocks = dict()
+
+
+def print_summary():
+    global i
+    print("\n\n########################## SUMMARY ##########################")
+    if (len(missing_deps) + len(outdated_deps) + len(check_manually)) > 0:
+        if len(missing_deps) > 0:
+            print("Missing dependencies:")
+            for i in reversed(missing_deps):
+                print("- " + i)
+
+        if len(outdated_deps) > 0:
+            print(
+                "\nDependencies that either need to be updated or rebuild for requested archs:"
+            )
+            for i in reversed(outdated_deps):
+                print("- " + i)
+
+        if len(check_manually) > 0:
+            print(
+                "\nDependencies that require manual attention as their repos could not be located:"
+            )
+            for i in reversed(check_manually):
+                print("- " + i)
+    else:
+        print(
+            "All dependencies are available to build {} {}".format(args.package_name, version)
+        )
+
+
+# Start the program.
+if __name__ == "__main__":
+    # Create parser
+    parser = create_parser()
+    # Get the parsed arguments and get to work!
+    args = parser.parse_args()
+
+    # Check if the package is accessible in the conda-forge channel
+    repo_avail, def_branch = is_recipe_available(args.package_name, True)
+    if not repo_avail:
+        print("unable to locate the {} package on conda-forge".format(args.package_name))
+        exit(1)
+
+    # Prepare the list of requested archs
+    archs = supportedArchs.copy()
+    if args.archs:
+        archs = []
+        for arch in args.archs.split():
+            if arch in supportedArchs:
+                archs.append(arch)
+            else:
+                print("{} arch is not supported. Please use the names from the \
+                      list: {}".format(arch, supportedArchs))
+                exit(1)
+
+    # Inspect and draw package's dependencies
+    deps, version = get_deps(args.package_name, def_branch, archs, args.check_version_check_selector)
+
+    print_level(deps, archs, " ", args.check_version_check_selector, args.expand_tree)
+
+    # print_summary()
+
+    feedstocks = ','.join(reversed(list(ordered_feedstocks.keys())))
+    print(feedstocks)

--- a/tools/render.py
+++ b/tools/render.py
@@ -1,0 +1,43 @@
+from jinja2 import Environment, FileSystemLoader
+from vendor import UndefinedNeverFail
+
+
+def ignore_undefined(undefined: set) -> set:
+    assert isinstance(undefined, set)
+
+    ignore = {
+        "PYTHON",
+        "python",
+        "environ",
+        "target_platform",
+        "compiler",
+        "cdt",
+        "pin_subpackage",
+        "pin_compatible",
+    }
+    return undefined - ignore
+
+
+def render_template(template, no_output=False):
+    """
+    Render the meta.yaml using Jinja2: return YAML data
+    This uses conda-build's jinja context to prevent failures for special conda-build
+    variables like {{ compiler('c') }} and any other undefined jinja expansions
+    """
+
+    if not template:
+        return ""
+
+    try:
+        rendered = template.render()
+    except TypeError:
+        print(f"NoneType template")
+        return ""
+
+    return rendered
+
+
+def load_template_string(data, no_output=False):
+    env = Environment(undefined=UndefinedNeverFail)
+    template = env.from_string(data)
+    return render_template(template, no_output=no_output)

--- a/tools/selector_support.py
+++ b/tools/selector_support.py
@@ -1,0 +1,81 @@
+arch_support = {
+    "linux-64": False,
+    "linux-ppc64le": False,
+    "linux-aarch64": False,
+    "linux-s390x": False,
+    "osx-64": False,
+    "osx-arm64": False,
+    "win-64": False,
+}
+
+arch_selector_template = {
+    "win": False,
+    "osx": False,
+    "x86_64": False,
+    "arm64": False,
+    "linux": False,
+    "linux64": False,
+    "s390x": False,
+    "aarch64": False,
+    "ppc64le": False,
+}
+
+
+class arch_selectors:
+    linux_64 = arch_selector_template.copy()
+    linux_64["linux"] = True
+    linux_64["x86_64"] = True
+    linux_64["linux64"] = True
+
+    linux_ppc64le = arch_selector_template.copy()
+    linux_ppc64le["linux"] = True
+    linux_ppc64le["ppc64le"] = True
+
+    linux_aarch64 = arch_selector_template.copy()
+    linux_aarch64["linux"] = True
+    linux_aarch64["aarch64"] = True
+
+    linux_s390x = arch_selector_template.copy()
+    linux_s390x["linux"] = True
+    linux_s390x["s390x"] = True
+
+    osx_64 = arch_selector_template.copy()
+    osx_64["osx"] = True
+    osx_64["x86_64"] = True
+
+    osx_arm64 = arch_selector_template.copy()
+    osx_arm64["osx"] = True
+    osx_arm64["arm64"] = True
+
+    win = arch_selector_template.copy()
+    win["win"] = True
+    win["x86_64"] = True
+
+
+archSelectorCombs = {
+    "linux-64": arch_selectors.linux_64,
+    "linux-ppc64le": arch_selectors.linux_ppc64le,
+    "linux-aarch64": arch_selectors.linux_aarch64,
+    "linux-s390x": arch_selectors.linux_s390x,
+    "osx-64": arch_selectors.osx_64,
+    "osx-arm64": arch_selectors.osx_arm64,
+    "win-64": arch_selectors.win,
+}
+
+
+def evaluate_arch_selector(archs2check, expression):
+    # archs2check as a list: ['win','linux-64','osx-arm64']
+    # expression as a string: 'linux or (osx and x86_64)'
+    archSupportDep = arch_support.copy()
+    for arch in archs2check:
+        if not expression:
+            archSupportDep[arch] = True
+        else:
+            try:
+                result = eval(expression, {}, archSelectorCombs[arch])
+                if result:
+                    archSupportDep[arch] = True
+            except:
+                archSupportDep[arch] = True
+
+    return archSupportDep

--- a/tools/vendor.py
+++ b/tools/vendor.py
@@ -1,0 +1,112 @@
+# Copyright (C) 2014 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+
+#
+#  This comes from conda_build/jinja_context.py
+#  conda-build has a lot of dependencies and this reduces the overhead
+#
+import jinja2
+
+
+class UndefinedNeverFail(jinja2.Undefined):
+    """
+    A class for Undefined jinja variables.
+    This is even less strict than the default jinja2.Undefined class,
+    because it permits things like {{ MY_UNDEFINED_VAR[:2] }} and
+    {{ MY_UNDEFINED_VAR|int }}. This can mask lots of errors in jinja templates, so it
+    should only be used for a first-pass parse, when you plan on running a 'strict'
+    second pass later.
+    Note:
+        When using this class, any usage of an undefined variable in a jinja template is recorded
+        in the (global) all_undefined_names class member.  Therefore, after jinja rendering,
+        you can detect which undefined names were used by inspecting that list.
+        Be sure to clear the all_undefined_names list before calling template.render().
+    """
+
+    all_undefined_names = []
+
+    def __init__(
+        self,
+        hint=None,
+        obj=jinja2.runtime.missing,
+        name=None,
+        exc=jinja2.exceptions.UndefinedError,
+    ):
+        jinja2.Undefined.__init__(self, hint, obj, name, exc)
+
+    # Using any of these methods on an Undefined variable
+    # results in another Undefined variable.
+    __add__ = (
+        __radd__
+    ) = (
+        __mul__
+    ) = (
+        __rmul__
+    ) = (
+        __div__
+    ) = (
+        __rdiv__
+    ) = (
+        __truediv__
+    ) = (
+        __rtruediv__
+    ) = (
+        __floordiv__
+    ) = (
+        __rfloordiv__
+    ) = (
+        __mod__
+    ) = (
+        __rmod__
+    ) = (
+        __pos__
+    ) = (
+        __neg__
+    ) = (
+        __call__
+    ) = (
+        __getitem__
+    ) = (
+        __lt__
+    ) = (
+        __le__
+    ) = (
+        __gt__
+    ) = (
+        __ge__
+    ) = (
+        __complex__
+    ) = __pow__ = __rpow__ = lambda self, *args, **kwargs: self._return_undefined(
+        self._undefined_name
+    )
+
+    # Accessing an attribute of an Undefined variable
+    # results in another Undefined variable.
+    def __getattr__(self, k):
+        try:
+            return object.__getattr__(self, k)
+        except AttributeError:
+            self._return_undefined(self._undefined_name + "." + k)
+
+    # Unlike the methods above, Python requires that these
+    # few methods must always return the correct type
+    __str__ = __repr__ = lambda self: self._return_value("")
+    __unicode__ = lambda self: self._return_value("")
+    __int__ = lambda self: self._return_value(0)
+    __float__ = lambda self: self._return_value(0.0)
+    __nonzero__ = lambda self: self._return_value(False)
+
+    def _return_undefined(self, result_name):
+        # Record that this undefined variable was actually used.
+        UndefinedNeverFail.all_undefined_names.append(self._undefined_name)
+        return UndefinedNeverFail(
+            hint=self._undefined_hint,
+            obj=self._undefined_obj,
+            name=result_name,
+            exc=self._undefined_exception,
+        )
+
+    def _return_value(self, value=None):
+        # Record that this undefined variable was actually used.
+        UndefinedNeverFail.all_undefined_names.append(self._undefined_name)
+        return value


### PR DESCRIPTION
This updates build action to take a package name as input and use that to run find_deps, which will then output an ordered list of feedstocks to be used as input into the rocket-platform build action.

This also updates add-repo to take a comma separated list of feedstock names and then remove the ones that already exist. This will enable us to call add-repo for the ordered list of feedstocks from find_deps

https://anaconda.atlassian.net/browse/CR-74