### PR TITLE
feat(workspace.osx-arm64.yaml): Add tomli-feedstock to the workspace

### DIFF
--- a/workspaces/workspace.osx-arm64.yaml
+++ b/workspaces/workspace.osx-arm64.yaml
@@ -18,3 +18,4 @@ recipes:
 - botocore-feedstock
 - s3transfer-feedstock
 - boto3-feedstock
+- tomli-feedstock


### PR DESCRIPTION
Adding tomli-feedstock. Feedstock has no dependencies other than python.

Jira: CR-45