### PR TITLE
feat: PR build

### DIFF
--- a/.github/workflows/build-feedstock.yml
+++ b/.github/workflows/build-feedstock.yml
@@ -1,39 +1,28 @@
-name: "Build feedstock"
+name: "Build feedstocks"
 
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
-      package:
-        description: 'Package to build'
+      feedstock:
+        description: 'Feedstock to build'
         required: true
         type: string
       arch:
         description: 'Architecture to target'
         default: "linux-64"
-        required: true
-        type: choice
-        options:
-          - linux-64
+        type: string
       container_runtime:
         description: 'The container runtime to use'
         default: none
-        type: choice
-        options:
-          - docker
-          - podman
-          - none
+        type: string
       branch:
         description: 'Branch from anaconda-community/aggregate youd like to build from'
         default: main
-        required: true
+        type: string
       action_runner:
         description: "The GitHub runner to use, only change when eks does not work"
         default: "self-hosted-eks"
-        required: true
-        type: choice
-        options:
-          - "self-hosted-eks"
-          - "ubuntu-latest"
+        type: string
 
 permissions: write-all
 
@@ -70,7 +59,7 @@ jobs:
       - name: Get build order
         id: build-order
         run: |
-          python tools/find_deps.py -p ${{ inputs.package }} > output.log
+          python tools/find_deps.py -f ${{ inputs.feedstock }} > output.log
           feedstocks=$(tail -n 1 output.log)
           echo "feedstocks=$feedstocks" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -1,0 +1,48 @@
+name: "Manual build feedstock"
+
+on:
+  workflow_dispatch:
+    inputs:
+      feedstock:
+        description: 'Feedstock to build'
+        required: true
+        type: string
+      arch:
+        description: 'Architecture to target'
+        default: "linux-64"
+        required: true
+        type: choice
+        options:
+          - linux-64
+      container_runtime:
+        description: 'The container runtime to use'
+        default: none
+        type: choice
+        options:
+          - docker
+          - podman
+          - none
+      branch:
+        description: 'Branch from anaconda-community/aggregate youd like to build from'
+        default: main
+        required: true
+      action_runner:
+        description: "The GitHub runner to use, only change when eks does not work"
+        default: "self-hosted-eks"
+        required: true
+        type: choice
+        options:
+          - "self-hosted-eks"
+          - "ubuntu-latest"
+
+permissions: write-all
+
+jobs:
+  build:
+    uses: anaconda-community/aggregate/.github/workflows/build-feedstock.yml@main
+    with:
+      feedstock: ${{ inputs.feedstock }}
+      arch: ${{ inputs.arch }}
+      container_runtime: ${{ inputs.container_runtime }}
+      branch: ${{ inputs.branch }}
+      feedaction_runnerstock: ${{ inputs.action_runner }}

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,0 +1,42 @@
+name: "PR build feedstock"
+
+on:
+  pull_request:
+    types: [opened, reopened]
+    branches:
+      - 'main'
+    paths:
+      - 'manifest.yaml'
+
+jobs:
+  find-feedstocks:
+    defaults:
+      run:
+        shell: bash -l {0}
+    outputs:
+      feedstocks: ${{ steps.feedstocks.outputs.feedstocks }}
+      branch:  ${{ steps.extract_branch.outputs.feedstocks }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3
+        with:
+          fetch-depth: 2
+
+      - name: Extract branch name
+        run: echo "branch=$(echo ${GITHUB_REF#refs/heads/})" >>$GITHUB_OUTPUT
+        id: extract_branch
+
+      - name: Get feedstocks
+        id: feedstocks
+        run: |
+          feedstocks=($(git diff HEAD^..HEAD --diff-filter=M | grep "+\s*.*-feedstock:" | sed -r 's#^\+[[:blank:]]+(.*-feedstock):$#\1#'))
+          printf -v joined '%s,' "${feedstocks[@]}"
+          echo "feedstocks=$joined" >>$GITHUB_OUTPUT
+
+  build:
+    needs: find-feedstocks
+    uses: anaconda-community/aggregate/.github/workflows/build-feedstock.yml@main
+    with:
+      feedstock: ${{ needs.find-feedstocks.outputs.feedstocks }}
+      branch: ${{ needs.find-feedstocks.outputs.branch }}

--- a/tools/README.md
+++ b/tools/README.md
@@ -4,13 +4,13 @@
 
 This project was copied from https://github.com/anaconda-distribution/distro-incubator/tree/main/akabanovs/pkg_check_availability and modified.
 
-This Python script generates a dependency tree for a specified package found on the conda-forge channel by default. The tool inspects the
+This Python script generates a dependency tree for a specified feedstock found on the conda-forge channel by default. The tool inspects the
 run dependencies required to build the package and checks for the existence of these dependencies conda-forge. It will output a list feedstocks in build order
 
 To install, create a new conda environment and install:
 	- pyyaml
 	- jinja2
 
-To run provide package name
+To run provide feedstock name
 
-`python find_deps.py -p urllib3`
+`python find_deps.py -f urllib3-feedstock`


### PR DESCRIPTION
Update find_deps to take a comma separated list of feedstocks and handle the full build order for multiple feedstocks.
Create a workflow that runs on PR when manifest is changed that will parse out the added feedstocks and run build. Currently only works on feedstock additions to manifest, does not parse changes to SHA or removal


https://anaconda.atlassian.net/browse/CR-73