### PR TITLE
fix(integration-test): integration test fix

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Build
         run: |
           gh secret set GH_TOKEN --body "$GITHUB_TOKEN"
-          gh -R anaconda-community/aggregate workflow run "Build feedstocks" \
+          gh -R anaconda-community/aggregate workflow run "Manual build feedstock" \
             -f feedstock=community-integration-test-feedstock \
             -f arch=linux-64 \
             -f branch=community-integration-test-branch \


### PR DESCRIPTION
Call the manual build feedstock in order to trigger the workflow_dispatch event from github cli