### PR TITLE
chore: remove empty maps from pinnings

### DIFF
--- a/.github/workflows/sync-pinnings.yml
+++ b/.github/workflows/sync-pinnings.yml
@@ -33,6 +33,11 @@ jobs:
         with:
           cmd: yq '. *= load("conda_build_config_community.yaml")' conda-forge/recipe/conda_build_config.yaml -i
 
+      - name: Remove keys with empty map
+        uses: mikefarah/yq@master
+        with:
+          cmd: yq e 'del(.. | select(tag == "!!map" and length == 0))' conda-forge/recipe/conda_build_config.yaml -i
+
       - name: Check-in change
         run: |
             branch=$(date +pinnings%Y%m%d%H%M%S)

--- a/conda_build_config_community.yaml
+++ b/conda_build_config_community.yaml
@@ -1,6 +1,8 @@
-channel_targets:
-channel_sources:
-libblas:
-libcblas:
-liblapack:
-liblapacke:
+channel_targets: {}
+channel_sources: {}
+libblas: {}
+libcblas: {}
+liblapack: {}
+liblapacke: {}
+docker_image: # [os.environ.get("BUILD_PLATFORM", "").startswith("linux-")]
+  - public.ecr.aws/y0o4y9o3/anaconda-pkg-build:latest


### PR DESCRIPTION
This allows us to remove entries from conda-forge pinnings by adding an empty map to community pinnings