### PR TITLE
refactor(datadog): add service tags and aggregate keys

### DIFF
--- a/.github/workflows/add-repo.yml
+++ b/.github/workflows/add-repo.yml
@@ -133,6 +133,7 @@ jobs:
         with:
           datadog-metric-prefix: 'community.repo.add-repo'
           metrics-type: 'job_metrics'
+          custom-tags: '["service:community-repo"]'
         env:
           DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
           OCTOKIT_TOKEN: ${{ secrets.GH_TOKEN }}
@@ -153,12 +154,14 @@ jobs:
         with:
           api-key: ${{ secrets.DATADOG_API_KEY }}
           events: |
-            - title: "Community Repo Feedstock Creation Error"
+            - title: "Unable to create feedstock ${{ matrix.feedstock }}"
+              aggregate_key: "community-repo/feedstock-creation-error"
               text: "Feedstock ${{ matrix.feedstock }} failed to fork."
               alert_type: "error"
               host: ${{ github.repository_owner }}
               tags:
                 - "@github.org:anaconda-community"
+                - "service:community-repo"
 
   send-dd-add-events:
     needs: add-repo
@@ -176,9 +179,11 @@ jobs:
         with:
           api-key: ${{ secrets.DATADOG_API_KEY }}
           events: |
-            - title: "Community Repo Feedstock Added"
+            - title: "Added feedstock ${{ matrix.feedstock }}"
+              aggregate_key: "community-repo/feedstock-created"
               text: "Feedstock ${{ matrix.feedstock }} was added."
               alert_type: "info"
               host: ${{ github.repository_owner }}
               tags:
                 - "@github.org:anaconda-community"
+                - "service:community-repo"

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -140,9 +140,11 @@ jobs:
           api-key: ${{ secrets.DATADOG_API_KEY }}
           events: |
             - title: "Community Repo Integration Test ${{ steps.install.outputs.test_result }}"
+              aggregate_key: "community-repo/integration-test-completed"
               text: "Test ${{ steps.install.outputs.test_result }}"
               alert_type: "${{ steps.install.outputs.test_result }}"
               host: ${{ github.repository_owner }}
               tags:
                 - "@github.org:anaconda-community"                
                 - "package-name:${{ steps.poll_repodata.outputs.repodata_package }}"
+                - "service:community-repo"

--- a/.github/workflows/remove-repo.yml
+++ b/.github/workflows/remove-repo.yml
@@ -80,9 +80,11 @@ jobs:
         with:
           api-key: ${{ secrets.DATADOG_API_KEY }}
           events: |
-            - title: "Community Repo Feedstock Removed"
+            - title: "Removed feedstock ${{ matrix.feedstock }}"
+              aggregate_key: "community-repo/feedstock-removed"
               text: "Feedstock ${{ matrix.feedstock }} was removed."
               alert_type: "info"
               host: ${{ github.repository_owner }}
               tags:
                 - "@github.org:anaconda-community"
+                - "service:community-repo"

--- a/.github/workflows/sbom-artifact-check.yml
+++ b/.github/workflows/sbom-artifact-check.yml
@@ -123,12 +123,14 @@ jobs:
           api-key: ${{ secrets.DATADOG_API_KEY }}
           events: |
             - title: "Community Repo SBOM Not Found"
+              aggregate_key: "community-repo/sbom-not-found"
               text: "The SBOM path was not found for repodata packages: ${{ steps.match_packages.outputs.not_found_packages }} with architecture: ${{ matrix.architecture }}"
               alert_type: "error"
               host: ${{ github.repository_owner }}
               tags:
                 - "@github.org:anaconda-community"
                 - architecture: ${{ matrix.architecture }}
+                - "service:community-repo"
 
       - name: Send SBOM Index Name Mistmatch Event
         uses: masci/datadog@v1
@@ -137,12 +139,14 @@ jobs:
           api-key: ${{ secrets.DATADOG_API_KEY }}
           events: |
             - title: "Community Repo SBOM Index Name Mismatch"
+              aggregate_key: "community-repo/sbom-index-name-mismatch"
               text: "The SBOM name was not found at the sbom path location: ${{ steps.index_path_check.outputs.no_name_sboms }} with architecture: ${{ matrix.architecture }}"
               alert_type: "error"
               host: ${{ github.repository_owner }}
               tags:
                 - "@github.org:anaconda-community"
                 - architecture: ${{ matrix.architecture }}
+                - "service:community-repo"
 
       - name: Send SBOM Metrics
         uses: masci/datadog@v1
@@ -154,15 +158,18 @@ jobs:
               value: ${{ steps.repodata_packages.outputs.repodata_packages_count }}
               tags:          
                 - "@github.org:anaconda-community"
+                - "service:community-repo"
             
             - type: "count"
               name: "community.repo.${{ matrix.architecture }}.sbom.paths.count"
               value: ${{ steps.sbom_index_paths.outputs.sbom_index_paths_count }}
               tags:          
                 - "@github.org:anaconda-community"
+                - "service:community-repo"
             
             - type: "count"
               name: "community.repo.${{ matrix.architecture }}.sbom.not_found_packages.count"
               value: ${{ steps.match_packages.outputs.not_found_packages_count }}
               tags:          
                 - "@github.org:anaconda-community"
+                - "service:community-repo"

--- a/.github/workflows/update-repo.yml
+++ b/.github/workflows/update-repo.yml
@@ -167,6 +167,7 @@ jobs:
               value: ${{ steps.feedstocks.outputs.feedstock_count }}
               tags:          
                 - "@github.org:anaconda-community"                    
+                - "service:community-repo"
 
     outputs:
       feedstocks: ${{ steps.formatted.outputs.feedstocks }}
@@ -184,6 +185,7 @@ jobs:
         with:
           datadog-metric-prefix: 'community.repo.update-repo'
           metrics-type: 'job_metrics'
+          custom-tags: '["service:community-repo"]'
         env:
           DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
           OCTOKIT_TOKEN: ${{ secrets.GH_TOKEN }}
@@ -204,12 +206,14 @@ jobs:
         with:
           api-key: ${{ secrets.DATADOG_API_KEY }}
           events: |
-            - title: "Community Repo Feedstock Updated"
+            - title: "Updated feedstock ${{ matrix.feedstock }}"
+              aggregate_key: "community-repo/feedstock-updated"
               text: "Feedstock ${{ matrix.feedstock }} was updated."
               alert_type: "info"
               host: ${{ github.repository_owner }}
               tags:
                 - "@github.org:anaconda-community"
+                - "service:community-repo"
 
   send-dd-error-events:
     needs: update-repo
@@ -227,9 +231,11 @@ jobs:
         with:
           api-key: ${{ secrets.DATADOG_API_KEY }}
           events: |
-            - title: "Community Repo Feedstock Update Error"
+            - title: "Unable to update feedstock ${{ matrix.feedstock }}"
+              aggregate_key: "community-repo/feedstock-update-error"
               text: "Feedstock ${{ matrix.feedstock }} failed to update."
               alert_type: "error"
               host: ${{ github.repository_owner }}
               tags:
                 - "@github.org:anaconda-community"
+                - "service:community-repo"


### PR DESCRIPTION
Adding the service tag and the aggregate_key to events following the pattern in the post-processing workflow so that we can navigate events together.

Jira: CR-5