### PR TITLE
refactor(metrics): add architecture tag

### DIFF
--- a/.github/workflows/sbom-artifact-check.yml
+++ b/.github/workflows/sbom-artifact-check.yml
@@ -128,7 +128,7 @@ jobs:
               host: ${{ github.repository_owner }}
               tags:
                 - "@github.org:anaconda-community"
-                - architecture: ${{ matrix.architecture }}
+                - "architecture:${{ matrix.architecture }}"
                 - "service:community-repo/post-process/sbom-check"        
 
 #      - name: Send SBOM Index Name Mistmatch Event
@@ -157,7 +157,7 @@ jobs:
               value: ${{ steps.repodata_packages.outputs.repodata_packages_count }}
               tags:          
                 - "@github.org:anaconda-community"
-                - architecture: ${{ matrix.architecture }}
+                - "architecture:${{ matrix.architecture }}"
                 - "service:community-repo/post-process/sbom-check"        
             
             - type: "count"
@@ -165,13 +165,13 @@ jobs:
               value: ${{ steps.sbom_index_paths.outputs.sbom_index_paths_count }}
               tags:          
                 - "@github.org:anaconda-community"
-                - architecture: ${{ matrix.architecture }}
+                - "architecture:${{ matrix.architecture }}"
                 - "service:community-repo/post-process/sbom-check"        
             
             - type: "count"
-              name: "community.repo.sbom.not_found_packages.count"
+              name: "community.repo.packages_missing_sbom.count"
               value: ${{ steps.match_packages.outputs.not_found_packages_count }}
               tags:          
                 - "@github.org:anaconda-community"
-                - architecture: ${{ matrix.architecture }}
+                - "architecture:${{ matrix.architecture }}"
                 - "service:community-repo/post-process/sbom-check"        


### PR DESCRIPTION
Restructure repo metrics to use architecture tag.


The "missing SBOM" metric name was changed to remove ambiguity in reading. There are two potential sets of mismatches: packages without a matching SBOM and SBOMs without a matching package. We are reporting the first, but the name (`sbom.not_found_packages`) could be read as meaning the second.