### PR TITLE
add back the testing feedstock

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,1 +1,4 @@
-feedstocks: []
+feedstocks:
+  community-integration-test-feedstock:
+    branch: main
+    commit: f547fdaf76ea973332a8f093c1282fa77040787e


### PR DESCRIPTION
We need the testing feedstock added to the manifest so we can run our integration tests.