### PR TITLE
quietly skip adding deps

### DIFF
--- a/.github/workflows/add-repo.yml
+++ b/.github/workflows/add-repo.yml
@@ -41,7 +41,8 @@ jobs:
       - name: Get dependencies
         id: deps
         run: |          
-          python tools/crawl_deptree.py -f ${{ github.event.inputs.feedstocks }} > output.log
+          # python tools/crawl_deptree.py -f ${{ github.event.inputs.feedstocks }} > output.log
+          touch output.log
           feedstocks+=$(tail -n 1 output.log)
           echo "feedstocks=$feedstocks" >> $GITHUB_OUTPUT
         env:


### PR DESCRIPTION
This should quietly skip adding dependencies.  This is a quick fix to get unblocked while [AX-241](https://anaconda.atlassian.net/browse/AX-241)