### PR TITLE
skip builds on PR open

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -2,7 +2,7 @@ name: "PR build feedstock"
 
 on:
   pull_request:
-    types: [closed, opened, reopened, synchronize]
+    types: [closed, reopened, synchronize]
     branches:
       - 'main'
     paths:


### PR DESCRIPTION
This causes problems when we're trying to re-populate the manifest.